### PR TITLE
CreateNotesファイルの復元

### DIFF
--- a/db/migrate/20250308112821_create_notes.rb
+++ b/db/migrate/20250308112821_create_notes.rb
@@ -1,7 +1,5 @@
 class CreateNotes < ActiveRecord::Migration[7.2]
   def change
-    return if ActiveRecord::Base.connection.table_exists?(:notes)
-    
     create_table :notes do |t|
       t.references :user, null: false, foreign_key: true
       t.string :title


### PR DESCRIPTION
前回のプルリクエスト時に記述した「マイグレーションファイルの適用をスキップする」という記述を削除。
直近のデプロイのマイグレーションファイルを最新復元するため。