### PR TITLE
画像のリンク化

### DIFF
--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,6 +1,8 @@
 <div class="bg-white shadow-md rounded-lg overflow-hidden mb-4">
   <div id="note-id-<%= note.id %>">
-    <%= link_to image_tag note.note_image_url, class: "w-full h-48 object-cover" %>
+    <%= link_to note_path(note) do %>
+      <%= image_tag note.note_image_url, class: "w-full h-48 object-cover" %>
+    <% end %>
     
   <div class="p-4">
     <div class="flex justify-between items-center mb-2">


### PR DESCRIPTION
# 概要
ノートの写真を押すと詳細画面へ遷移するようにリンク化しました。

## 📝追加・修正した機能
- 同上

## ✅追加・修正した箇所
- `image_tag`を`<%= link_to note_path(note) do %>`で記載

## 💡次回の修正予定
-  ノート詳細画面のレイアウト修正