### PR TITLE
重複したメールアドレスでの新規登録のエラーメッセージの修正

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -88,5 +88,6 @@ ja:
               blank: "を入力してください"
             email:
               blank: "を入力してください"
+              taken: "はすでに登録されています"
             password:
               blank: "を入力してください"


### PR DESCRIPTION
# 概要
登録済みメールアドレスを新規登録時に入力した際のバリデーションエラーメッセージを修正

## 📝追加・修正した機能
- 新規登録画面でのバリデーションエラーメッセージを修正しました。

## できるようになったこと
- 日本語で表示されるようになったため、エラーが視認しやすくなりました。

## 動作確認
- ローカル環境での動作は確認済みです。

## その他
- 特になし。
